### PR TITLE
feat: add option to ignore specified users & collaborators

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,12 @@ With this GitHub workflow, you can automate tasks whenever an author creates mul
 ### Use cases
 
 - The workflow can comment the issues that are already created by the author which are currently in the open state.
-- You can also filter the issues that are assigned to you
+- You can also filter the issues that are assigned to the author of the issue
 - You can add your own comment message (even multiline) in the issue.
 - You can add label or labels based on your preferences.
 - Optionally, you can also close the issue (previous issues won't be affected), and only the current issue will be closed.
+- You can ignore this workflow for specific users by using `ignoreUsers`
+- You can directly pass `ignoreCollaborators`
 
 ---
 
@@ -53,6 +55,8 @@ Various inputs are defined to let you configure the action:
 | `close` | This will close the issue if set to true | `'false'` |
 | `issueNumber` | This will comment all the previous issues that are created by the author | `'true'` |
 | `assign` | This will filter the issues that are assigned to the author (works only if `issueNumber` is `true`) | `'false'` |
+| `ignoreUsers` | Specify usernames that should be ignored while running this workflow. Use commas to separate if there are multiple users. | `''` |
+| `ignoreCollaborators` | This will ignore all the collaborators in the repository while running this workflow | `'false'` |
 
 <br>
 
@@ -176,6 +180,50 @@ with:
 #  Suppose #1, #2 is already created by the author. But only #2 is assigned to the author.
 #  Output
 #  #2 has been opened by you and is also assigned to you.
+```
+
+</details>
+
+<br>
+
+<details>
+  <summary>To ignore specified users while running this workflow</summary>
+
+<br>
+
+  - Suppose, we have to ignore this workflow for users with username: `Anmol-Baranwal`, `AnmolB2`.
+
+```yml
+uses: Anmol-Baranwal/handle-multiple-issues@v1
+with:
+  issueNumber: true   # default is true
+  ignoreUsers: 'Anmol-Baranwal, AnmolB2'
+
+#  Suppose Anmol-Baranwal created an issue. You will receive a log message during the workflow execution.
+#  Log Message
+#  User: Anmol-Baranwal is on the ignore list. Ignoring the workflow for this user.
+```
+
+</details>
+
+<br>
+
+<details>
+  <summary>To ignore collaborators of the repository while running this workflow</summary>
+
+<br>
+
+  - Suppose, we have to ignore this workflow for users with username: `Anmol-Baranwal`, `AnmolB2`.
+
+```yml
+uses: Anmol-Baranwal/handle-multiple-issues@v1
+with:
+  issueNumber: true   # default is true
+  ignoreCollaborators: true
+
+#  Suppose Anmol-Baranwal created an issue and is a collaborator. You will receive a log message during the workflow execution.
+#  Log Message
+#  User: Anmol-Baranwal is a collaborator. Ignoring the issue for collaborators.
 ```
 
 </details>

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ inputs:
     description: 'To filter the issues that are assigned to the author'
     default: 'false'
     required: false
-  ignore-users:
+  ignoreUsers:
     description: 'Specify usernames that should be ignored while running this workflow'
     default: 'false'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
     required: false
   ignoreUsers:
     description: 'Specify usernames that should be ignored while running this workflow'
-    default: 'false'
+    default: ''
     required: false
   ignoreCollaborators:
     description: 'Ignore all the collaborators in the repository while running this workflow'

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: 'To filter the issues that are assigned to the author'
     default: 'false'
     required: false
+  ignore-users:
+    description: 'Specify usernames that should be ignored while running this workflow'
+    default: 'false'
+    required: false
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: 'Specify usernames that should be ignored while running this workflow'
     default: 'false'
     required: false
+  ignoreCollaborators:
+    description: 'Ignore all the collaborators in the repository while running this workflow'
+    default: 'false'
+    required: false
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -53,9 +53,14 @@ async function HandleMultipleIssues() {
         const issueNumber = core.getInput("issueNumber") === "true";
         const comment = core.getInput("comment");
         const close = core.getInput("close") === "true" || false;
+        const ignoreUsers = core.getInput("ignore-users").split(",").map(user => user.trim());
         const checkComment = comment.trim() !== "";
         // Check if the same author has open issues
         const author = (_a = context.payload.issue) === null || _a === void 0 ? void 0 : _a.user.login;
+        if (ignoreUsers.includes(author)) {
+            core.notice(`User: ${author} is on the ignore list. Ignoring the workflow for this user.`);
+            return; // No need to continue.
+        }
         core.notice("step 2.");
         const { data: authorIssues } = await octokit.rest.issues.listForRepo({
             owner: context.repo.owner,

--- a/dist/index.js
+++ b/dist/index.js
@@ -48,12 +48,19 @@ async function HandleMultipleIssues() {
         const context = github.context;
         core.notice("step 1.");
         // Retrieve custom inputs
-        const labels = core.getInput("label").split(",").map(label => label.trim());
+        const labels = core
+            .getInput("label")
+            .split(",")
+            .map((label) => label.trim());
         const assign = core.getInput("assign") === "true" || false;
         const issueNumber = core.getInput("issueNumber") === "true";
         const comment = core.getInput("comment");
         const close = core.getInput("close") === "true" || false;
-        const ignoreUsers = core.getInput("ignore-users").split(",").map(user => user.trim());
+        const ignoreUsers = core
+            .getInput("ignore-users")
+            .split(",")
+            .map((user) => user.trim());
+        const ignoreCollaboratorsInput = core.getInput("ignoreCollaborators") === "true" || false;
         const checkComment = comment.trim() !== "";
         // Check if the same author has open issues
         const author = (_a = context.payload.issue) === null || _a === void 0 ? void 0 : _a.user.login;
@@ -61,18 +68,30 @@ async function HandleMultipleIssues() {
             core.notice(`User: ${author} is on the ignore list. Ignoring the workflow for this user.`);
             return; // No need to continue.
         }
+        const collaboratorUsernames = ignoreCollaboratorsInput
+            ? (await octokit.rest.repos.listCollaborators({
+                owner: context.repo.owner,
+                repo: context.repo.repo
+            })).data.map((collaborator) => collaborator.login)
+            : [];
+        if (collaboratorUsernames.includes(author)) {
+            core.notice(`User ${author} is a collaborator. Ignoring the issue for collaborators.`);
+            return; // No need to continue.
+        }
         core.notice("step 2.");
         const { data: authorIssues } = await octokit.rest.issues.listForRepo({
             owner: context.repo.owner,
             repo: context.repo.repo,
             creator: author,
-            state: "open",
+            state: "open"
         });
         const filteredIssues = assign
             ? authorIssues.filter((issue) => issue.assignees.some((assignee) => assignee.login === author))
             : authorIssues;
         if (filteredIssues.length === 0) {
-            core.notice(`No existing ${assign === true ? "issues created by and assigned to" : "open issues for"} this author.`);
+            core.notice(`No existing ${assign === true
+                ? "issues created by and assigned to"
+                : "open issues for"} this author.`);
             return; // No need to continue.
         }
         core.notice("step 3.");
@@ -91,7 +110,7 @@ async function HandleMultipleIssues() {
                         owner: context.repo.owner,
                         repo: context.repo.repo,
                         issue_number: issueNumberToLabel,
-                        labels: [lbl],
+                        labels: [lbl]
                     });
                 }
             }
@@ -101,7 +120,7 @@ async function HandleMultipleIssues() {
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     issue_number: issueNumberToLabel,
-                    labels: [labels],
+                    labels: [labels]
                 });
             }
             core.notice("Labels added to issue #" + issueNumberToLabel);
@@ -124,7 +143,7 @@ async function HandleMultipleIssues() {
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     issue_number: issueNumberToLabel,
-                    body: commentText,
+                    body: commentText
                 });
                 core.notice("Comment added to issue #" + issueNumberToLabel);
             }
@@ -134,7 +153,7 @@ async function HandleMultipleIssues() {
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     issue_number: issueNumberToLabel,
-                    body: comment,
+                    body: comment
                 });
                 core.notice("Comment added to issue #" + issueNumberToLabel);
             }
@@ -144,7 +163,7 @@ async function HandleMultipleIssues() {
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     issue_number: issueNumberToLabel,
-                    state: "closed",
+                    state: "closed"
                 });
                 core.notice("Issue #" + issueNumberToLabel + " closed");
             }

--- a/dist/index.js
+++ b/dist/index.js
@@ -57,7 +57,7 @@ async function HandleMultipleIssues() {
         const comment = core.getInput("comment");
         const close = core.getInput("close") === "true" || false;
         const ignoreUsers = core
-            .getInput("ignore-users")
+            .getInput("ignoreUsers")
             .split(",")
             .map((user) => user.trim());
         const ignoreCollaboratorsInput = core.getInput("ignoreCollaborators") === "true" || false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,11 +26,17 @@ async function HandleMultipleIssues() {
     const issueNumber = core.getInput("issueNumber") === "true";
     const comment = core.getInput("comment");
     const close = core.getInput("close") === "true" || false;
+    const ignoreUsers = core.getInput("ignore-users").split(",").map(user => user.trim());
 
     const checkComment = comment.trim() !== "";
 
     // Check if the same author has open issues
     const author = context.payload.issue?.user.login;
+
+    if (ignoreUsers.includes(author)) {
+      core.notice(`User: ${author} is on the ignore list. Ignoring the workflow for this user.`);
+      return; // No need to continue.
+    }
 
     core.notice("step 2.");
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ async function HandleMultipleIssues() {
     const comment = core.getInput("comment")
     const close = core.getInput("close") === "true" || false
     const ignoreUsers = core
-      .getInput("ignore-users")
+      .getInput("ignoreUsers")
       .split(",")
       .map((user) => user.trim())
     const ignoreCollaboratorsInput =

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,51 +1,77 @@
-import * as core from "@actions/core";
-import * as github from "@actions/github";
+import * as core from "@actions/core"
+import * as github from "@actions/github"
 
 async function HandleMultipleIssues() {
   try {
-    const token = core.getInput("gh-token");
+    const token = core.getInput("gh-token")
 
-    if (!token) core.debug(token + "");
-    else core.debug(token);
+    if (!token) core.debug(token + "")
+    else core.debug(token)
 
     if (!token) {
       core.setFailed(
         "GitHub token is missing. Make sure to set the GITHUB_TOKEN secret."
-      );
-      return;
+      )
+      return
     }
 
-    const octokit = github.getOctokit(token);
-    const context = github.context;
+    const octokit = github.getOctokit(token)
+    const context = github.context
 
-    core.notice("step 1.");
+    core.notice("step 1.")
 
     // Retrieve custom inputs
-    const labels = core.getInput("label").split(",").map(label => label.trim());
-    const assign = core.getInput("assign")  === "true" || false;
-    const issueNumber = core.getInput("issueNumber") === "true";
-    const comment = core.getInput("comment");
-    const close = core.getInput("close") === "true" || false;
-    const ignoreUsers = core.getInput("ignore-users").split(",").map(user => user.trim());
+    const labels = core
+      .getInput("label")
+      .split(",")
+      .map((label) => label.trim())
+    const assign = core.getInput("assign") === "true" || false
+    const issueNumber = core.getInput("issueNumber") === "true"
+    const comment = core.getInput("comment")
+    const close = core.getInput("close") === "true" || false
+    const ignoreUsers = core
+      .getInput("ignore-users")
+      .split(",")
+      .map((user) => user.trim())
+    const ignoreCollaboratorsInput =
+      core.getInput("ignoreCollaborators") === "true" || false
 
-    const checkComment = comment.trim() !== "";
+    const checkComment = comment.trim() !== ""
 
     // Check if the same author has open issues
-    const author = context.payload.issue?.user.login;
+    const author = context.payload.issue?.user.login
 
     if (ignoreUsers.includes(author)) {
-      core.notice(`User: ${author} is on the ignore list. Ignoring the workflow for this user.`);
-      return; // No need to continue.
+      core.notice(
+        `User: ${author} is on the ignore list. Ignoring the workflow for this user.`
+      )
+      return // No need to continue.
     }
 
-    core.notice("step 2.");
+    const collaboratorUsernames = ignoreCollaboratorsInput
+      ? (
+          await octokit.rest.repos.listCollaborators({
+            owner: context.repo.owner,
+            repo: context.repo.repo
+          })
+        ).data.map((collaborator) => collaborator.login)
+      : []
 
-    const { data: authorIssues } = await octokit.rest.issues.listForRepo({
+    if (collaboratorUsernames.includes(author)) {
+      core.notice(
+        `User ${author} is a collaborator. Ignoring the issue for collaborators.`
+      )
+      return // No need to continue.
+    }
+
+    core.notice("step 2.")
+
+    const {data: authorIssues} = await octokit.rest.issues.listForRepo({
       owner: context.repo.owner,
       repo: context.repo.repo,
       creator: author,
-      state: "open",
-    });
+      state: "open"
+    })
 
     const filteredIssues = assign
       ? authorIssues.filter((issue: any) =>
@@ -53,27 +79,29 @@ async function HandleMultipleIssues() {
         )
       : authorIssues
 
-      if (filteredIssues.length === 0) {
-        core.notice(
-          `No existing ${
-            assign === true ? "issues created by and assigned to" : "open issues for"
-          } this author.`
-        )
-        return // No need to continue.
-      }
+    if (filteredIssues.length === 0) {
+      core.notice(
+        `No existing ${
+          assign === true
+            ? "issues created by and assigned to"
+            : "open issues for"
+        } this author.`
+      )
+      return // No need to continue.
+    }
 
-    core.notice("step 3.");
+    core.notice("step 3.")
 
     const previousIssueNumbers = filteredIssues
-      .filter((issue: { number: any }) => issue.number !== context.issue.number) // Exclude the current issue
-      .map((issue: { number: any }) => issue.number);
+      .filter((issue: {number: any}) => issue.number !== context.issue.number) // Exclude the current issue
+      .map((issue: {number: any}) => issue.number)
 
     if (previousIssueNumbers.length > 0) {
-      const issueNumberToLabel = context.issue.number;
+      const issueNumberToLabel = context.issue.number
 
       const issueLinks = previousIssueNumbers
         .map((issueNumber: any) => `#${issueNumber}`)
-        .join(", ");
+        .join(", ")
 
       // Check if label is an array and add multiple labels if needed
       if (Array.isArray(labels)) {
@@ -82,8 +110,8 @@ async function HandleMultipleIssues() {
             owner: context.repo.owner,
             repo: context.repo.repo,
             issue_number: issueNumberToLabel,
-            labels: [lbl],
-          });
+            labels: [lbl]
+          })
         }
       } else {
         // Add a single label
@@ -91,35 +119,36 @@ async function HandleMultipleIssues() {
           owner: context.repo.owner,
           repo: context.repo.repo,
           issue_number: issueNumberToLabel,
-          labels: [labels],
-        });
+          labels: [labels]
+        })
       }
 
-      core.notice("Labels added to issue #" + issueNumberToLabel);
+      core.notice("Labels added to issue #" + issueNumberToLabel)
 
       // Add comments based on conditions
       if (issueNumber) {
         // const issueLink = `#${issueNumberToLabel}`;
-        let commentText: string = "";
+        let commentText: string = ""
 
         if (!checkComment) {
           // Condition 1: issueNumber is true, comment is false
 
-          if(assign)  commentText = `${issueLinks} has been opened by you and is also assigned to you.`;
-          else commentText = `${issueLinks} is already opened by you.`;
+          if (assign)
+            commentText = `${issueLinks} has been opened by you and is also assigned to you.`
+          else commentText = `${issueLinks} is already opened by you.`
         } else if (checkComment) {
           // Condition 2: issueNumber is true, comment is true
-          commentText = `${issueLinks} ${comment}`;
+          commentText = `${issueLinks} ${comment}`
         }
 
         await octokit.rest.issues.createComment({
           owner: context.repo.owner,
           repo: context.repo.repo,
           issue_number: issueNumberToLabel,
-          body: commentText,
-        });
+          body: commentText
+        })
 
-        core.notice("Comment added to issue #" + issueNumberToLabel);
+        core.notice("Comment added to issue #" + issueNumberToLabel)
       } else if (!issueNumber && checkComment) {
         // Condition 3: issueNumber is false, comment is true
 
@@ -127,10 +156,10 @@ async function HandleMultipleIssues() {
           owner: context.repo.owner,
           repo: context.repo.repo,
           issue_number: issueNumberToLabel,
-          body: comment,
-        });
+          body: comment
+        })
 
-        core.notice("Comment added to issue #" + issueNumberToLabel);
+        core.notice("Comment added to issue #" + issueNumberToLabel)
       }
 
       // Close the current issue if close is true
@@ -139,16 +168,16 @@ async function HandleMultipleIssues() {
           owner: context.repo.owner,
           repo: context.repo.repo,
           issue_number: issueNumberToLabel,
-          state: "closed",
-        });
+          state: "closed"
+        })
 
-        core.notice("Issue #" + issueNumberToLabel + " closed");
+        core.notice("Issue #" + issueNumberToLabel + " closed")
       }
     }
   } catch (error: any) {
-    core.notice("No Issue found!");
-    core.notice("Workflow failed: " + error.message);
+    core.notice("No Issue found!")
+    core.notice("Workflow failed: " + error.message)
   }
 }
 
-HandleMultipleIssues();
+HandleMultipleIssues()


### PR DESCRIPTION
- Introduced the `ignoreUsers` option, allowing you to specify usernames for exclusion from this workflow.

- Implemented the `ignoreCollaborators` option to automatically ignore all repository collaborators during workflow execution.

- Included examples and updated documentation to illustrate both options.